### PR TITLE
allow null/mixed stype_in

### DIFF
--- a/databento/common/symbology.py
+++ b/databento/common/symbology.py
@@ -242,7 +242,10 @@ class InstrumentMap:
             # Nothing to do
             return
 
-        stype_in = SType(metadata.stype_in)
+        try:
+            stype_in = SType(metadata.stype_in)
+        except ValueError:
+            stype_in = None
         stype_out = SType(metadata.stype_out)
 
         for symbol_in, entries in metadata.mappings.items():


### PR DESCRIPTION
## Description

the python currently cannot read dbn files with mixed stype_in since it will try to read the stype and then throw due to the null value. this PR aims to make the behavior consistent with the Rust code, and allow python to read files with mixed stype_in.

Fixes # (issue)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test 1. read a file with mixed stype_in and convert it with .to_df method. before this patch, it would fail, with this patch it completes.


### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
